### PR TITLE
Number of CPUs should be a runtime argument, not an input.

### DIFF
--- a/strelka-job.yml
+++ b/strelka-job.yml
@@ -10,4 +10,3 @@ reference:
 config:
     class: File
     path: strelka_config_bwa_default.ini
-cpu_count: 8

--- a/strelka.cwl
+++ b/strelka.cwl
@@ -7,6 +7,8 @@ baseCommand: "/usr/bin/cwl_helper.sh"
 requirements:
     DockerRequirement:
         dockerPull: "mgibio/strelka-cwl:1.0.15"
+arguments:
+    - { valueFrom: $(runtime.cores), position: 5 }
 inputs:
     tumor_bam:
         type: File
@@ -27,10 +29,6 @@ inputs:
         type: File
         inputBinding:
             position: 4
-    cpu_count:
-        type: int
-        inputBinding:
-            position: 5
 outputs:
      all_indels:
          type: File


### PR DESCRIPTION
The runtime will inform the tool how many cores it has to work with.