### PR TITLE
Set min cores for strelka.

### DIFF
--- a/strelka.cwl
+++ b/strelka.cwl
@@ -7,6 +7,8 @@ baseCommand: "/usr/bin/cwl_helper.sh"
 requirements:
     DockerRequirement:
         dockerPull: "mgibio/strelka-cwl:1.0.15"
+    ResourceRequirement:
+        coresMin: 8
 arguments:
     - { valueFrom: $(runtime.cores), position: 5 }
 inputs:


### PR DESCRIPTION
I did a trial with:
```yaml
   coresMin: 4
   coresMax: 8
```
and it (unsurprisingly) used 4 to run in our trial.  This PR sets a minimum of 8 with no upper bound.