### PR TITLE
Updates for Arvados-compatibility

### DIFF
--- a/varscan/varscan_processsomatic.cwl
+++ b/varscan/varscan_processsomatic.cwl
@@ -3,10 +3,10 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "varscan v2.4.2 processSomatic"
-baseCommand: "processSomatic"
+baseCommand: ["java", "-jar", "/opt/varscan/VarScan.jar", "processSomatic"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/varscan:v2.4.2"
+      dockerPull: "mgibio/varscan-cwl:v2.4.2-samtools1.3.1"
     - class: InitialWorkDirRequirement
       listing:
         - $(inputs.variants)

--- a/varscan/varscan_processsomatic.cwl
+++ b/varscan/varscan_processsomatic.cwl
@@ -7,7 +7,6 @@ baseCommand: "processSomatic"
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/varscan:v2.4.2"
-    - class: InlineJavascriptRequirement
     - class: InitialWorkDirRequirement
       listing:
         - $(inputs.variants)
@@ -16,7 +15,7 @@ inputs:
         type: File
         inputBinding:
             valueFrom:
-                $(runtime.outdir + "/" + self.basename)
+                $(runtime.outdir)/$(self.basename)
             position: 1
 outputs:
     somatic_hc:

--- a/varscan/varscan_somatic.cwl
+++ b/varscan/varscan_somatic.cwl
@@ -3,21 +3,24 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "varscan v2.4.2 somatic"
-baseCommand: "somatic"
+baseCommand: "/usr/bin/cwl_helper.sh"
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/varscan:v2.4.2"
-arguments:
-    - { valueFrom: $(runtime.outdir)/output }
-    - "--mpileup"
-    - "1"
-    - "--output-vcf"
+      dockerPull: "mgibio/varscan-cwl:v2.4.2-samtools1.3.1"
 inputs:
-    mpileup:
+    tumor_bam:
         type: File
         inputBinding:
-            position: -1 #before arguments
-        streamable: true
+            position: 1
+    normal_bam:
+        type: File
+        inputBinding:
+            position: 2
+    reference:
+        type: File
+        inputBinding:
+            position: 3
+        secondaryFiles: .fai
 outputs:
     snvs:
         type: File

--- a/varscan/varscan_somatic.cwl
+++ b/varscan/varscan_somatic.cwl
@@ -7,9 +7,8 @@ baseCommand: "somatic"
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/varscan:v2.4.2"
-    - class: InlineJavascriptRequirement
 arguments:
-    - { valueFrom: $(runtime.outdir + "/output") }
+    - { valueFrom: $(runtime.outdir)/output }
     - "--mpileup"
     - "1"
     - "--output-vcf"

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -55,18 +55,12 @@ outputs:
         type: File
         outputSource: process_somatic_indels/loh
 steps:
-    mpileup:
-        run: samtools_mpileup.cwl
+    somatic:
+        run: varscan_somatic.cwl
         in:
             reference: reference
             normal_bam: normal_bam
             tumor_bam: tumor_bam
-        out:
-            [mpileup]
-    somatic:
-        run: varscan_somatic.cwl
-        in:
-            mpileup: mpileup/mpileup
         out:
             [snvs, indels]
     process_somatic_snvs:


### PR DESCRIPTION
We can't use `ENTRYPOINT` or `streamable` at present, so this adds a helper script to stream the `mpileup` output into VarScan and revises the workflow accordingly.