### PR TITLE
initial version of example pipeline yaml

### DIFF
--- a/detect_variants/combine_variants.cwl
+++ b/detect_variants/combine_variants.cwl
@@ -6,7 +6,7 @@ label: "CombineVariants (GATK 3.6)"
 baseCommand: ["/usr/local/bin/jdk1.8.0_45/bin/java", "-jar", "/usr/local/bin/GATK3.6/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "dbmi/gatk-docker:latest@sha256:7e7d7911d51b0109cd1db1b5ac824287c7af013da29fe28022289ff62940f0be" #GATK 3.6 at a specific container revision
+      dockerPull: "dbmi/gatk-docker:v1" #GATK 3.6 at a specific container revision
 arguments:
     ["-genotypeMergeOptions", "PRIORITIZE",
      "--rod_priority_list", "mutect,varscan,strelka",

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -6,7 +6,7 @@ label: "SelectVariants (GATK 3.6)"
 baseCommand: ["/usr/local/bin/jdk1.8.0_45/bin/java", "-jar", "/usr/local/bin/GATK3.6/GenomeAnalysisTK.jar", "-T", "SelectVariants"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "dbmi/gatk-docker:latest@sha256:7e7d7911d51b0109cd1db1b5ac824287c7af013da29fe28022289ff62940f0be" #GATK 3.6 at a specific container revision
+      dockerPull: "dbmi/gatk-docker:v1" #GATK 3.6 at a specific container revision
 arguments:
     ["-o", { valueFrom: $(runtime.outdir)/output.vcf.gz }]
 inputs:

--- a/example_data/pipeline.yaml
+++ b/example_data/pipeline.yaml
@@ -1,0 +1,30 @@
+#!/usr/bin/env cwl-runner
+cwl:tool: pipeline.cwl
+reference:
+  class: File
+  path: keep:591f8a4326389d97bbbb01ddd1bcd606+8203/GRCh38_full_analysis_set_plus_decoy_hla.fa
+mills:
+  class: File
+  path: keep:591f8a4326389d97bbbb01ddd1bcd606+8203/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
+known_indels:
+  class: File
+  path: keep:591f8a4326389d97bbbb01ddd1bcd606+8203/Homo_sapiens_assembly38.known_indels.vcf.gz
+dbsnp:
+  class: File
+  path: keep:591f8a4326389d97bbbb01ddd1bcd606+8203/Homo_sapiens_assembly38.dbsnp138.vcf.gz
+cosmic_vcf:
+  class: File
+  path: keep:591f8a4326389d97bbbb01ddd1bcd606+8203/Cosmic_v79.dictsorted.vcf.gz
+interval_list:
+  class: File
+  path: keep:d8abfaae11ae3416b6bb95f72671d133+205/xgen-exome-research-panel-targets.interval_list
+strelka_exome_mode: true
+normal_bams:
+  - { class: File, path: 'keep:941c6c78bb08a2c41685a5ad90b7371e+2270/gerald_H7HY2CCXX_3_ATCACGGT.bam' }
+  - { class: File, path: 'keep:dcbb053a3c91d430478be8c6bfe673a8+2227/gerald_H7HY2CCXX_4_ATCACGGT.bam' }
+normal_readgroups: ['@RG\tID:2895499223\tPL:ILLUMINA\tPU:H7HY2CCXX-ATCACGGT.3\tLB:H_NJ-HCC1395-HCC1395-lg24-lib1\tSM:H_NJ-HCC1395-HCC1395', '@RG\tID:2895499237\tPL:ILLUMINA\tPU:H7HY2CCXX-ATCACGGT.4\tLB:H_NJ-HCC1395-HCC1395-lg24-lib1\tSM:H_NJ-HCC1395-HCC1395']
+tumor_bams:
+  - { class: File, path: 'keep:9058985e1fc8c14e505b451a6750b514+2228/gerald_H7HY2CCXX_3_TGACCACG.bam' }
+  - { class: File, path: 'keep:74836c0e5588d30ae8e0ec6ac6af0f2d+2144/gerald_H7HY2CCXX_4_TGACCACG.bam' }
+tumor_readgroups: ['@RG\tID:2895499331\tPL:ILLUMINA\tPU:H7HY2CCXX-TGACCACG.3\tLB:H_NJ-HCC1395-HCC1395_BL-lg21-lib1\tSM:H_NJ-HCC1395-HCC1395_BL', '@RG\tID:2895499399\tPL:ILLUMINA\tPU:H7HY2CCXX-TGACCACG.4\tLB:H_NJ-HCC1395-HCC1395_BL-lg21-lib1\tSM:H_NJ-HCC1395-HCC1395_BL']
+

--- a/mutect/mutect.cwl
+++ b/mutect/mutect.cwl
@@ -6,7 +6,7 @@ label: "mutect2 (GATK 3.6)"
 baseCommand: ["/usr/local/bin/jdk1.8.0_45/bin/java", "-jar", "/usr/local/bin/GATK3.6/GenomeAnalysisTK.jar", "-T", "MuTect2"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "dbmi/gatk-docker:latest@sha256:7e7d7911d51b0109cd1db1b5ac824287c7af013da29fe28022289ff62940f0be" #GATK 3.6 at a specific container revision
+      dockerPull: "dbmi/gatk-docker:v1" #Instead of specific GATK 3.6 commit hash, since Arvados has issues with specific commit hashes
 arguments:
     ["-o", { valueFrom: $(runtime.outdir)/output.vcf.gz }]
 inputs:

--- a/varscan/set_filter_status.cwl
+++ b/varscan/set_filter_status.cwl
@@ -6,7 +6,7 @@ label: "create filtered VCF"
 baseCommand: ["/usr/local/bin/jdk1.8.0_45/bin/java", "-jar", "/usr/local/bin/GATK3.6/GenomeAnalysisTK.jar", "-T", "VariantFiltration"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "dbmi/gatk-docker:latest@sha256:7e7d7911d51b0109cd1db1b5ac824287c7af013da29fe28022289ff62940f0be" #GATK 3.6 at a specific container revision
+      dockerPull: "dbmi/gatk-docker:v1" #GATK 3.6 at a specific container revision
 arguments:
     ["--maskName", "processSomatic",
     "--filterNotInMask",


### PR DESCRIPTION
@susannasiebert  is this what you had in mind for the yaml?

I have not tested this since it appears the Docker daemon is not running on the shell node:

```
jwalker@shell:~/git/arvados_trial$ arvados-cwl-runner --project-uuid=testx-j7d0g-h48gaxtcg7tfsgl --output-name "HCC1395 Exome GRCh38DH 1" --no-wait --debug pipeline.cwl pipeline.yml
/usr/bin/arvados-cwl-runner 1.0.20161017193526, arvados-python-client 0.1.20161017101604, cwltool 1.0.20161007181528
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
Unhandled error, try again with --debug for more information:
  Command '['docker', 'images', '--no-trunc', '--all']' returned non-zero exit status 1
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/cwltool/main.py", line 702, in main
    **vars(args))
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/__init__.py", line 271, in arv_executor
    upload_instance(self, shortname(tool.tool["id"]), tool, job_order)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/runner.py", line 116, in upload_instance
    upload_docker(arvrunner, tool)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/runner.py", line 113, in upload_docker
    upload_docker(arvrunner, s.embedded_tool)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/runner.py", line 113, in upload_docker
    upload_docker(arvrunner, s.embedded_tool)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/runner.py", line 113, in upload_docker
    upload_docker(arvrunner, s.embedded_tool)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/runner.py", line 110, in upload_docker
    arv_docker_get_image(arvrunner.api, docker_req, True, arvrunner.project_uuid)
  File "/usr/lib/python2.7/dist-packages/arvados_cwl/arvdocker.py", line 26, in arv_docker_get_image
    imageId = cwltool.docker.get_image(dockerRequirement, pull_image)
  File "/usr/lib/python2.7/dist-packages/cwltool/docker.py", line 21, in get_image
    ["docker", "images", "--no-trunc", "--all"]).splitlines():
  File "/usr/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
CalledProcessError: Command '['docker', 'images', '--no-trunc', '--all']' returned non-zero exit status 1
```