### PR TITLE
Reduce sambamba memory to 12G; specify the resource request in CWL.

### DIFF
--- a/unaligned_bam_to_bqsr/name_sort.cwl
+++ b/unaligned_bam_to_bqsr/name_sort.cwl
@@ -6,12 +6,14 @@ label: 'sort BAM by name'
 baseCommand: ["/usr/local/bin/sambamba", "sort"]
 arguments: 
     ["-t", "8",
-    "-m", "18G",
+    "-m", "12G",
     "-n",
     "-o", { valueFrom: $(runtime.outdir)/NameSorted.bam }]
 requirements:
     - class: DockerRequirement
       dockerPull: "registry.gsc.wustl.edu/genome/sambamba-0.6.4:1"
+    - class: ResourceRequirement
+      ramMin: 12000
 inputs:
     bam:
         type: File


### PR DESCRIPTION
Seems like we ought to have a tmp space specification, too. (How much we need is likely related to the size of the input.)