### PR TITLE
Specify all secondary file suffixes as arrays.

### DIFF
--- a/detect_variants/combine_variants.cwl
+++ b/detect_variants/combine_variants.cwl
@@ -23,19 +23,19 @@ inputs:
         inputBinding:
             prefix: "--variant:mutect"
             position: 2
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     varscan_vcf:
         type: File
         inputBinding:
             prefix: "--variant:varscan"
             position: 3
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     strelka_vcf:
         type: File
         inputBinding:
             prefix: "--variant:strelka"
             position: 4
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 outputs:
     combined_vcf:
         type: File

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -11,25 +11,25 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     dbsnp_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     cosmic_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     strelka_exome_mode:
         type: boolean
 outputs:
     final_vcf:
         type: File
         outputSource: index/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     mutect:
         run: ../mutect/workflow.cwl

--- a/detect_variants/fp_filter.cwl
+++ b/detect_variants/fp_filter.cwl
@@ -16,13 +16,13 @@ inputs:
         inputBinding:
             prefix: "--reference"
             position: 1
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     bam:
         type: File
         inputBinding:
             prefix: "--bam-file"
             position: 2
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     vcf:
         type: File
         inputBinding:

--- a/detect_variants/index.cwl
+++ b/detect_variants/index.cwl
@@ -21,7 +21,7 @@ inputs:
 outputs:
     indexed_vcf:
         type: File
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
         outputBinding:
             glob: $(inputs.vcf.basename)
 

--- a/detect_variants/merge.cwl
+++ b/detect_variants/merge.cwl
@@ -19,7 +19,7 @@ inputs:
         type: File[]
         inputBinding:
             position: 1
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 outputs:
     merged_vcf:
         type: File

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -21,7 +21,7 @@ inputs:
         inputBinding:
             prefix: "--variant"
             position: 2
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     interval_list:
         type: File
         inputBinding:

--- a/mutect/mutect.cwl
+++ b/mutect/mutect.cwl
@@ -21,13 +21,13 @@ inputs:
         inputBinding:
             prefix: "-I:tumor"
             position: 2
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
         inputBinding:
             prefix: "-I:normal"
             position: 3
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     interval_list:
         type: File
         inputBinding:
@@ -38,13 +38,13 @@ inputs:
         inputBinding:
             prefix: "--dbsnp"
             position: 5
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     cosmic_vcf:
         type: File?
         inputBinding:
             prefix: "--cosmic"
             position: 6
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 outputs:
     vcf:
         type: File

--- a/mutect/mutect_and_index.cwl
+++ b/mutect/mutect_and_index.cwl
@@ -10,18 +10,18 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     dbsnp_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     cosmic_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 outputs:
     vcf:
         type: File

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -13,10 +13,10 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     scatter_count:
@@ -24,15 +24,15 @@ inputs:
         default: 50
     dbsnp_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     cosmic_vcf:
         type: File?
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 outputs:
     merged_vcf:
         type: File
         outputSource: index/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     split_interval_list:
         run: ../detect_variants/split_interval_list.cwl

--- a/strelka/process_vcf.cwl
+++ b/strelka/process_vcf.cwl
@@ -10,7 +10,7 @@ outputs:
     processed_vcf:
         type: File
         outputSource: index/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     add_gt:
         run: add_gt.cwl

--- a/strelka/strelka.cwl
+++ b/strelka/strelka.cwl
@@ -19,21 +19,21 @@ inputs:
             prefix: '--tumorBam='
             separate: false
             position: 3
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
         inputBinding:
             prefix: '--normalBam='
             separate: false
             position: 4
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     reference:
         type: File
         inputBinding:
             prefix: '--referenceFasta='
             separate: false
             position: 5
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     exome_mode:
         type: boolean
         inputBinding:

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -10,13 +10,13 @@ requirements:
 inputs:
     tumor_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     normal_bam:
         type: File
-        secondaryFiles: .bai
+        secondaryFiles: [.bai]
     reference:
         type: File
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     interval_list:
         type: File
     exome_mode:
@@ -25,7 +25,7 @@ outputs:
     merged_vcf:
         type: File
         outputSource: index_filtered/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     strelka:
         run: strelka.cwl

--- a/varscan/bgzip_and_index.cwl
+++ b/varscan/bgzip_and_index.cwl
@@ -10,7 +10,7 @@ outputs:
     indexed_vcf:
         type: File
         outputSource: index/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     bgzip:
         run: ../detect_variants/bgzip.cwl

--- a/varscan/samtools_mpileup.cwl
+++ b/varscan/samtools_mpileup.cwl
@@ -15,7 +15,7 @@ inputs:
         inputBinding:
             prefix: "-f"
             position: 2
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     normal_bam:
         type: File
         inputBinding:

--- a/varscan/set_filter_status.cwl
+++ b/varscan/set_filter_status.cwl
@@ -17,13 +17,13 @@ inputs:
         inputBinding:
             prefix: "--variant"
             position: 2
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     filtered_vcf:
         type: File
         inputBinding:
             prefix: "--mask"
             position: 3
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     reference:
         type: File
         inputBinding:

--- a/varscan/varscan.cwl
+++ b/varscan/varscan.cwl
@@ -6,7 +6,7 @@ label: "varscan somatic workflow"
 inputs:
     reference:
         type: File
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     tumor_bam:
         type: File
     normal_bam:

--- a/varscan/varscan_somatic.cwl
+++ b/varscan/varscan_somatic.cwl
@@ -20,7 +20,7 @@ inputs:
         type: File
         inputBinding:
             position: 3
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     roi_bed:
         type: File?
         inputBinding:

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -9,7 +9,7 @@ requirements:
 inputs:
     reference:
         type: File
-        secondaryFiles: .fai
+        secondaryFiles: [.fai]
     tumor_bam:
         type: File
     normal_bam:
@@ -20,15 +20,15 @@ outputs:
     snvs:
         type: File
         outputSource: index_snvs/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     indels:
         type: File
         outputSource: index_indels/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
     merged_vcf:
         type: File
         outputSource: index/indexed_vcf
-        secondaryFiles: .tbi
+        secondaryFiles: [.tbi]
 steps:
     intervals_to_bed:
         run: intervals_to_bed.cwl


### PR DESCRIPTION
The spec looks like it supports either format, but our cwl-runner prefers the array form.