### PR TITLE
One more secondaryFiles as string to array conversion.

### DIFF
--- a/unaligned_bam_to_bqsr/apply_bqsr.cwl
+++ b/unaligned_bam_to_bqsr/apply_bqsr.cwl
@@ -39,4 +39,4 @@ outputs:
         type: File
         outputBinding:
             glob: "Final.bam"
-        secondaryFiles: [".bai"]
+        secondaryFiles: [.bai]


### PR DESCRIPTION
Update the output of apply_bqsr to use an array instead of string for secondaryFiles.