### PR TITLE
BAM index(.bai) suffix 

### DIFF
--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -11,10 +11,10 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     dbsnp_vcf:

--- a/detect_variants/fp_filter.cwl
+++ b/detect_variants/fp_filter.cwl
@@ -22,7 +22,7 @@ inputs:
         inputBinding:
             prefix: "--bam-file"
             position: 2
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     vcf:
         type: File
         inputBinding:

--- a/mutect/mutect.cwl
+++ b/mutect/mutect.cwl
@@ -21,13 +21,13 @@ inputs:
         inputBinding:
             prefix: "-I:tumor"
             position: 2
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
         inputBinding:
             prefix: "-I:normal"
             position: 3
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
         inputBinding:

--- a/mutect/mutect_and_index.cwl
+++ b/mutect/mutect_and_index.cwl
@@ -10,10 +10,10 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     dbsnp_vcf:

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -13,10 +13,10 @@ inputs:
         secondaryFiles: [".fai", "^.dict"]
     tumor_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     scatter_count:

--- a/qc/collect_alignment_summary_metrics.cwl
+++ b/qc/collect_alignment_summary_metrics.cwl
@@ -16,7 +16,7 @@ inputs:
         type: File
         inputBinding:
             prefix: "INPUT="
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     reference:
         type: File
         inputBinding:

--- a/qc/collect_hs_metrics.cwl
+++ b/qc/collect_hs_metrics.cwl
@@ -16,7 +16,7 @@ inputs:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     reference:
         type: File
         inputBinding:

--- a/qc/collect_insert_size_metrics.cwl
+++ b/qc/collect_insert_size_metrics.cwl
@@ -17,7 +17,7 @@ inputs:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
 outputs:
     insert_size_metrics:
         type: File

--- a/qc/samtools_flagstat.cwl
+++ b/qc/samtools_flagstat.cwl
@@ -13,7 +13,7 @@ inputs:
         type: File
         inputBinding:
             position: 1
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
 outputs:
     flagstats:
         type: stdout

--- a/qc/workflow_exome.cwl
+++ b/qc/workflow_exome.cwl
@@ -8,7 +8,7 @@ requirements:
 inputs:
     bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     reference:
         type: File
         secondaryFiles: [.fai]

--- a/strelka/strelka.cwl
+++ b/strelka/strelka.cwl
@@ -19,14 +19,14 @@ inputs:
             prefix: '--tumorBam='
             separate: false
             position: 3
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
         inputBinding:
             prefix: '--normalBam='
             separate: false
             position: 4
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     reference:
         type: File
         inputBinding:

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -10,10 +10,10 @@ requirements:
 inputs:
     tumor_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
     reference:
         type: File
         secondaryFiles: [.fai]

--- a/unaligned_bam_to_bqsr/apply_bqsr.cwl
+++ b/unaligned_bam_to_bqsr/apply_bqsr.cwl
@@ -39,4 +39,4 @@ outputs:
         type: File
         outputBinding:
             glob: "Final.bam"
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]

--- a/unaligned_bam_to_bqsr/workflow.cwl
+++ b/unaligned_bam_to_bqsr/workflow.cwl
@@ -29,7 +29,7 @@ outputs:
     final_bam:
         type: File
         outputSource: apply_bqsr/bqsr_bam
-        secondaryFiles: [.bai]
+        secondaryFiles: [^.bai]
 steps:
     align:
         scatter: [bam, readgroup]


### PR DESCRIPTION
GATK does not output a .bam.bai suffix but rather only .bai suffix. Account for this in downstream secondaryFiles that use the BQSR BAM file