### PR TITLE
Switch expected Bam Index Name for Pindel Workflow

### DIFF
--- a/pindel/pindel.cwl
+++ b/pindel/pindel.cwl
@@ -25,7 +25,7 @@ inputs:
         type: File
         secondaryFiles: ["^.bai"]
     normal_bam:
-        type: File     
+        type: File
         secondaryFiles: ["^.bai"]
     reference:
         type: File

--- a/pindel/pindel.cwl
+++ b/pindel/pindel.cwl
@@ -23,10 +23,10 @@ arguments:
 inputs:
     tumor_bam:
         type: File
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     normal_bam:
         type: File     
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     reference:
         type: File
         inputBinding:

--- a/pindel/pindel_cat.cwl
+++ b/pindel/pindel_cat.cwl
@@ -10,10 +10,10 @@ inputs:
         secondaryFiles: [".fai"]
     tumor_bam:
         type: File
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     normal_bam:
         type: File
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     chromosome:
         type: string
     insert_size:

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -13,10 +13,10 @@ inputs:
         secondaryFiles: [".fai"]
     tumor_bam:
         type: File
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     normal_bam:
         type: File
-        secondaryFiles: [".bai"]
+        secondaryFiles: ["^.bai"]
     interval_list:
         type: File
     insert_size:


### PR DESCRIPTION
A few more places need `"^.bai"` to go along with the alternate naming standard.