### PR TITLE
Make bam index files and use them as normal/tumor.bam.bai

### DIFF
--- a/pindel/get_bam_index.cwl
+++ b/pindel/get_bam_index.cwl
@@ -1,0 +1,22 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "samtools index"
+baseCommand: ["index"]
+requirements:
+    - class: DockerRequirement
+      dockerPull: "mgibio/samtools:1.3.1"
+arguments:
+    - position: 2
+      valueFrom: $(runtime.outdir)/$(inputs.bam.basename).bai
+inputs:
+    bam:
+        type: File
+        inputBinding:
+            position: 1
+outputs:
+    bam_index:
+        type: File
+        outputBinding:
+            glob: $(inputs.bam.basename).bai

--- a/pindel/pindel.cwl
+++ b/pindel/pindel.cwl
@@ -16,6 +16,10 @@ requirements:
             entry: $(inputs.tumor_bam)
           - entryname: normal.bam
             entry: $(inputs.normal_bam)
+          - entryname: tumor.bam.bai
+            entry: $(inputs.tumor_bam_index)
+          - entryname: normal.bam.bai
+            entry: $(inputs.normal_bam_index)
           - entryname: 'pindel.config'
             entry: |
                 normal.bam $(inputs.insert_size)    NORMAL
@@ -27,10 +31,12 @@ arguments:
 inputs:
     tumor_bam:
         type: File
-        secondaryFiles: ["^.bai"]
     normal_bam:
         type: File
-        secondaryFiles: ["^.bai"]
+    tumor_bam_index:
+        type: File
+    normal_bam_index:
+        type: File
     reference:
         type: File
         inputBinding:

--- a/pindel/pindel_cat.cwl
+++ b/pindel/pindel_cat.cwl
@@ -10,10 +10,12 @@ inputs:
         secondaryFiles: [".fai"]
     tumor_bam:
         type: File
-        secondaryFiles: ["^.bai"]
     normal_bam:
         type: File
-        secondaryFiles: ["^.bai"]
+    tumor_bam_index:
+        type: File
+    normal_bam_index:
+        type: File
     chromosome:
         type: string
     insert_size:
@@ -30,6 +32,8 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
+            tumor_bam_index: tumor_bam_index
+            normal_bam_index: normal_bam_index
             insert_size: insert_size
             chromosome: chromosome
         out:

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -28,6 +28,18 @@ outputs:
         outputSource: index_filtered/indexed_vcf
         secondaryFiles: [".tbi"]
 steps:
+    get_tumor_bam_index:
+        run: get_bam_index.cwl
+        in:
+            bam: tumor_bam
+        out:
+            [bam_index]
+    get_normal_bam_index:
+        run: get_bam_index.cwl
+        in:
+            bam: normal_bam
+        out:
+            [bam_index]
     get_chromosome_list:
         run: get_chromosome_list.cwl
         in: 
@@ -41,6 +53,8 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
+            tumor_bam_index: [get_tumor_bam_index/bam_index]
+            normal_bam_index: [get_normal_bam_index/bam_index]
             chromosome: [get_chromosome_list/chromosome_list]
             insert_size: insert_size
         out:


### PR DESCRIPTION
Currently it is hard to figure out the path of bam secondary files aka .bai. This PR is an alternative way to work around the issue and keep arvados pipeline test running. We can refactor this once a solution is found in the future.