### PR TITLE
Strelka2 gzips its outputs, so expect that in the subsequent step.

### DIFF
--- a/strelka/add_gt.cwl
+++ b/strelka/add_gt.cwl
@@ -3,13 +3,16 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "add GT tags"
-baseCommand: "/usr/bin/awk"
+baseCommand: "/bin/zcat"
 requirements:
-    DockerRequirement:
-        dockerPull: "ubuntu:xenial"
+    - class: DockerRequirement
+      dockerPull: "ubuntu:xenial"
+    - class: ShellCommandRequirement
 arguments:
+    - valueFrom: $(inputs.vcf.path)
+    - '|'
+    - '/usr/bin/awk'
     - '{if(/^##/) print; else if(/^#/) print "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"$0; else print $1"\t"$2"\t"$3"\t"$4"\t"$5"\t"$6"\t"$7"\t"$8"\tGT:"$9"\t./.:"$10"\t./.:"$11;}'
-stdin: $(inputs.vcf.path)
 stdout: 'output.gt.vcf'
 inputs:
     vcf:


### PR DESCRIPTION
This worked for me with `cwltool`... hopefully it is similarly successful in our larger workflow!