### PR TITLE
FP filter paths

### DIFF
--- a/fp_filter/fp_filter.cwl
+++ b/fp_filter/fp_filter.cwl
@@ -10,6 +10,8 @@ requirements:
       tmpdirMin: 25000
 arguments:
     ["--sample", "TUMOR",
+    "--bam-readcount", "/usr/bin/bam-readcount",
+    "--samtools", "/opt/samtools/bin/samtools",
     "--output", { valueFrom: $(runtime.outdir)/filtered.vcf }]
 inputs:
     reference:


### PR DESCRIPTION
Provide the paths to the location of bam-readcount and samtools rather than hard-coding it in the fpfilter.pl script.

This is required before this is merged:
https://github.com/genome/docker-cle/pull/27
