### PR TITLE
Per variant caller VCF

### DIFF
--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -51,6 +51,45 @@ inputs:
         type: string[]?
         default: [GT,AD]
 outputs:
+    mutect_unfiltered_vcf:
+        type: File
+        outputSource mutect/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    mutect_filtered_vcf:
+        type: File
+        outputSource mutect/filtered_vcf
+        secondaryFiles: [.tbi]
+    strelka_unfiltered_vcf:
+        type: File
+        outputSource strelka/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    strelka_filtered_vcf:
+        type: File
+        outputSource strelka/filtered_vcf
+        secondaryFiles: [.tbi]
+    varscan_unfiltered_vcf:
+        type: File
+        outputSource varscan/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    varscan_filtered_vcf:
+        type: File
+        outputSource varscan/filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_unfiltered_vcf:
+        type: File
+        outputSource pindel/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    pindel_filtered_vcf:
+        type: File
+        outputSource pindel/filtered_vcf
+        secondaryFiles: [.tbi]
+    docm_unfiltered_vcf:
+        type: File
+        outputSource docm/unfiltered_vcf
+    docm_filtered_vcf:
+        type: File
+        outputSource docm/filtered_vcf
+        secondaryFiles: [.tbi]
     final_vcf:
         type: File
         outputSource: index/indexed_vcf
@@ -74,7 +113,7 @@ steps:
             scatter_count: mutect_scatter_count
             artifact_detection_mode: mutect_artifact_detection_mode
         out:
-            [merged_vcf]
+            [unfiltered_vcf, filtered_vcf]
     strelka:
         run: ../strelka/workflow.cwl
         in:
@@ -84,7 +123,7 @@ steps:
             interval_list: interval_list
             exome_mode: strelka_exome_mode
         out:
-            [merged_vcf]
+            [unfiltered_vcf, filtered_vcf]
     varscan:
         run: ../varscan/workflow.cwl
         in:
@@ -93,7 +132,7 @@ steps:
             normal_cram: normal_cram
             interval_list: interval_list
         out:
-            [merged_vcf]
+            [unfiltered_vcf, filtered_vcf]
     pindel:
         run: ../pindel/workflow.cwl
         in:
@@ -103,7 +142,7 @@ steps:
             interval_list: interval_list
             insert_size: pindel_insert_size
         out:
-            [merged_vcf]
+            [unfiltered_vcf, filtered_vcf]
     docm:
         run: ../docm/workflow.cwl
         in:
@@ -113,30 +152,22 @@ steps:
             docm_vcf: docm_vcf
             interval_list: interval_list
         out:
-            [merged_vcf]
+            [unfiltered_vcf, filtered_vcf]
     combine:
         run: combine_variants.cwl
         in:
             reference: reference
-            mutect_vcf: mutect/merged_vcf
-            strelka_vcf: strelka/merged_vcf
-            varscan_vcf: varscan/merged_vcf
-            pindel_vcf: pindel/merged_vcf
-            docm_vcf: docm/merged_vcf
+            mutect_vcf: mutect/filtered_vcf
+            strelka_vcf: strelka/filtered_vcf
+            varscan_vcf: varscan/filtered_vcf
+            pindel_vcf: pindel/filtered_vcf
+            docm_vcf: docm/filtered_vcf
         out:
             [combined_vcf]
-    hard_filter:
-        run: select_variants.cwl
-        in:
-            reference: reference
-            vcf: combine/combined_vcf
-            exclude_filtered: hard_filter_vcf
-        out:
-            [filtered_vcf]
     annotate_variants:
         run: vep.cwl
         in:
-            vcf: hard_filter/filtered_vcf
+            vcf: combine/combined_vcf
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: coding_only

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -53,42 +53,42 @@ inputs:
 outputs:
     mutect_unfiltered_vcf:
         type: File
-        outputSource mutect/unfiltered_vcf
+        outputSource: mutect/unfiltered_vcf
         secondaryFiles: [.tbi]
     mutect_filtered_vcf:
         type: File
-        outputSource mutect/filtered_vcf
+        outputSource: mutect/filtered_vcf
         secondaryFiles: [.tbi]
     strelka_unfiltered_vcf:
         type: File
-        outputSource strelka/unfiltered_vcf
+        outputSource: strelka/unfiltered_vcf
         secondaryFiles: [.tbi]
     strelka_filtered_vcf:
         type: File
-        outputSource strelka/filtered_vcf
+        outputSource: strelka/filtered_vcf
         secondaryFiles: [.tbi]
     varscan_unfiltered_vcf:
         type: File
-        outputSource varscan/unfiltered_vcf
+        outputSource: varscan/unfiltered_vcf
         secondaryFiles: [.tbi]
     varscan_filtered_vcf:
         type: File
-        outputSource varscan/filtered_vcf
+        outputSource: varscan/filtered_vcf
         secondaryFiles: [.tbi]
     pindel_unfiltered_vcf:
         type: File
-        outputSource pindel/unfiltered_vcf
+        outputSource: pindel/unfiltered_vcf
         secondaryFiles: [.tbi]
     pindel_filtered_vcf:
         type: File
-        outputSource pindel/filtered_vcf
+        outputSource: pindel/filtered_vcf
         secondaryFiles: [.tbi]
     docm_unfiltered_vcf:
         type: File
-        outputSource docm/unfiltered_vcf
+        outputSource: docm/unfiltered_vcf
     docm_filtered_vcf:
         type: File
-        outputSource docm/filtered_vcf
+        outputSource: docm/filtered_vcf
         secondaryFiles: [.tbi]
     final_vcf:
         type: File

--- a/detect_variants/detect_variants.cwl
+++ b/detect_variants/detect_variants.cwl
@@ -41,9 +41,6 @@ inputs:
         type: File?
     coding_only:
         type: boolean?
-    hard_filter_vcf:
-        type: boolean?
-        default: true
     variants_to_table_fields:
         type: string[]?
         default: [CHROM,POS,ID,REF,ALT,set,AC,AF]

--- a/detect_variants/merge.cwl
+++ b/detect_variants/merge.cwl
@@ -10,15 +10,18 @@ arguments:
     - "--output-type"
     - "z"
     - "-o"
-    - { valueFrom: $(runtime.outdir)/merged.vcf.gz }
+    - { valueFrom: $(runtime.outdir)/$(inputs.merged_vcf_basename).vcf.gz }
 inputs:
     vcfs:
         type: File[]
         inputBinding:
             position: 1
         secondaryFiles: [.tbi]
+    merged_vcf_basename:
+        type: string?
+        default: 'merged'
 outputs:
     merged_vcf:
         type: File
         outputBinding:
-            glob: "merged.vcf.gz"
+            glob: $(inputs.merged_vcf_basename).vcf.gz

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -33,8 +33,11 @@ inputs:
         inputBinding:
             prefix: "--excludeFiltered"
             position: 4
+    variant_caller:
+        type: string?
     output_vcf_basename:
-        type: string
+        type: string?
+        default: select_variants
 outputs:
     filtered_vcf:
         type: File

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
 arguments:
-    ["-o", { valueFrom: $(runtime.outdir)/output.vcf.gz }]
+    ["-o", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf.gz }]
 inputs:
     reference:
         type: File
@@ -33,8 +33,11 @@ inputs:
         inputBinding:
             prefix: "--excludeFiltered"
             position: 4
+    output_vcf_basename:
+        type: string?
+        default: output
 outputs:
     filtered_vcf:
         type: File
         outputBinding:
-            glob: "output.vcf.gz"
+            glob: $(inputs.output_vcf_basename).vcf.gz

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -33,8 +33,6 @@ inputs:
         inputBinding:
             prefix: "--excludeFiltered"
             position: 4
-    variant_caller:
-        type: string?
     output_vcf_basename:
         type: string?
         default: select_variants

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -1,4 +1,4 @@
-#!/usr/bin/env cwl-runner
+ll#!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
 class: CommandLineTool
@@ -34,8 +34,7 @@ inputs:
             prefix: "--excludeFiltered"
             position: 4
     output_vcf_basename:
-        type: string?
-        default: output
+        type: string
 outputs:
     filtered_vcf:
         type: File

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -1,4 +1,4 @@
-ll#!/usr/bin/env cwl-runner
+#!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
 class: CommandLineTool

--- a/detect_variants/select_variants.cwl
+++ b/detect_variants/select_variants.cwl
@@ -41,5 +41,6 @@ inputs:
 outputs:
     filtered_vcf:
         type: File
+        secondaryFiles: [.tbi]
         outputBinding:
             glob: $(inputs.output_vcf_basename).vcf.gz

--- a/docm/workflow.cwl
+++ b/docm/workflow.cwl
@@ -21,7 +21,10 @@ inputs:
     interval_list:
         type: File
 outputs:
-    merged_vcf:
+    unfiltered_vcf:
+        type: File
+        outputSource: GATK_haplotype_caller/docm_out
+    filtered_vcf:
         type: File
         outputSource: index/indexed_vcf
         secondaryFiles: [.tbi]

--- a/fp_filter/fp_filter.cwl
+++ b/fp_filter/fp_filter.cwl
@@ -12,7 +12,7 @@ arguments:
     ["--sample", "TUMOR",
     "--bam-readcount", "/usr/bin/bam-readcount",
     "--samtools", "/opt/samtools/bin/samtools",
-    "--output", { valueFrom: $(runtime.outdir)/filtered.vcf }]
+    "--output", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf }]
 inputs:
     reference:
         type: File
@@ -30,9 +30,12 @@ inputs:
         inputBinding:
             prefix: "--vcf-file"
             position: 3
+    output_vcf_basename:
+        type: string?
+        default: fpfilter
 outputs:
     filtered_vcf:
         type: File
         outputBinding:
-            glob: "filtered.vcf"
+            glob: $(inputs.output_vcf_basename).vcf
 

--- a/fp_filter/fp_filter.cwl
+++ b/fp_filter/fp_filter.cwl
@@ -30,8 +30,11 @@ inputs:
         inputBinding:
             prefix: "--vcf-file"
             position: 3
+    variant_caller:
+        type: string?
     output_vcf_basename:
-        type: string
+        type: string?
+        default: fpfilter
 outputs:
     filtered_vcf:
         type: File

--- a/fp_filter/fp_filter.cwl
+++ b/fp_filter/fp_filter.cwl
@@ -31,8 +31,7 @@ inputs:
             prefix: "--vcf-file"
             position: 3
     output_vcf_basename:
-        type: string?
-        default: fpfilter
+        type: string
 outputs:
     filtered_vcf:
         type: File

--- a/fp_filter/fp_filter.cwl
+++ b/fp_filter/fp_filter.cwl
@@ -30,8 +30,6 @@ inputs:
         inputBinding:
             prefix: "--vcf-file"
             position: 3
-    variant_caller:
-        type: string?
     output_vcf_basename:
         type: string?
         default: fpfilter

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -42,7 +42,7 @@ steps:
             bam: cram_to_bam/bam
             vcf: vcf
             output_vcf_basename: 
-                valueFrom: ${inputs.output_vcf_basename)_unfiltered
+                valueFrom: $(inputs.output_vcf_basename)_unfiltered
         out:
             [filtered_vcf]
     fp_bgzip:

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -13,13 +13,18 @@ inputs:
     vcf:
         type: File
         secondaryFiles: [.tbi]
-    filtered_vcf_basename:
+    output_vcf_basename:
         type: string?
-        default: filtered
+        default: fpfilter
 outputs:
+    unfiltered_vcf:
+        type: File
+        outputSource: fp_index/indexed_vcf
+        secondaryFiles: [.tbi]
     filtered_vcf:
         type: File
         outputSource: hard_filter/filtered_vcf
+        secondaryFiles: [.tbi]
 steps:
     cram_to_bam:
         run: cram_to_bam.cwl
@@ -34,6 +39,7 @@ steps:
             reference: reference
             bam: cram_to_bam/bam
             vcf: vcf
+            output_vcf_basename: ${inputs.output_vcf_basename)_unfiltered
         out:
             [filtered_vcf]
     fp_bgzip:
@@ -54,7 +60,7 @@ steps:
             reference: reference
             vcf: fp_index/indexed_vcf
             exclude_filtered: hard_filter_vcf
-            output_vcf_basename: filtered_vcf_basename
+            output_vcf_basename: $(inputs.output_vcf_basename)_filtered
         out:
             [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -40,7 +40,7 @@ steps:
             vcf: vcf
             output_vcf_basename:
                 source: variant_caller
-                valueFrom: $(self)_unfiltered
+                valueFrom: $(self)_full
         out:
             [filtered_vcf]
     fp_bgzip:

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -16,8 +16,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     output_vcf_basename:
-        type: string?
-        default: fpfilter
+        type: string
 outputs:
     unfiltered_vcf:
         type: File
@@ -63,7 +62,7 @@ steps:
             reference: reference
             vcf: fp_index/indexed_vcf
             exclude_filtered: 
-                default: "hard_filter_vcf"
+                default: true
             output_vcf_basename: 
                 valueFrom: $(inputs.output_vcf_basename)_filtered
         out:

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -3,6 +3,8 @@
 cwlVersion: v1.0
 class: Workflow
 label: "fp_filter workflow"
+requirements:
+    - class: InlineJavascriptRequirement
 inputs:
     cram:
         type: File
@@ -39,7 +41,8 @@ steps:
             reference: reference
             bam: cram_to_bam/bam
             vcf: vcf
-            output_vcf_basename: ${inputs.output_vcf_basename)_unfiltered
+            output_vcf_basename: 
+                valueFrom: ${inputs.output_vcf_basename)_unfiltered
         out:
             [filtered_vcf]
     fp_bgzip:
@@ -60,7 +63,8 @@ steps:
             reference: reference
             vcf: fp_index/indexed_vcf
             exclude_filtered: hard_filter_vcf
-            output_vcf_basename: $(inputs.output_vcf_basename)_filtered
+            output_vcf_basename: 
+                valueFrom: $(inputs.output_vcf_basename)_filtered
         out:
             [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -62,7 +62,8 @@ steps:
         in:
             reference: reference
             vcf: fp_index/indexed_vcf
-            exclude_filtered: hard_filter_vcf
+            exclude_filtered: 
+                default: "hard_filter_vcf"
             output_vcf_basename: 
                 valueFrom: $(inputs.output_vcf_basename)_filtered
         out:

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -41,7 +41,7 @@ steps:
             bam: cram_to_bam/bam
             vcf: vcf
             output_vcf_basename: 
-                valueFrom: $(inputs.output_vcf_basename)_unfiltered
+                valueFrom: $(inputs.output_vcf_basename + "_unfiltered")
         out:
             [filtered_vcf]
     fp_bgzip:
@@ -64,7 +64,7 @@ steps:
             exclude_filtered: 
                 default: true
             output_vcf_basename: 
-                valueFrom: $(inputs.output_vcf_basename)_filtered
+                valueFrom: $(inputs.output_vcf_basename + "_filtered")
         out:
             [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -13,10 +13,13 @@ inputs:
     vcf:
         type: File
         secondaryFiles: [.tbi]
+    filtered_vcf_basename:
+        type: string?
+        default: filtered
 outputs:
     filtered_vcf:
         type: File
-        outputSource: fp_filter/filtered_vcf
+        outputSource: hard_filter/filtered_vcf
 steps:
     cram_to_bam:
         run: cram_to_bam.cwl
@@ -33,5 +36,25 @@ steps:
             vcf: vcf
         out:
             [filtered_vcf]
-
+    fp_bgzip:
+        run: ../detect_variants/bgzip.cwl
+        in:
+            file: fp_filter/filtered_vcf
+        out:
+            [bgzipped_file]
+    fp_index:
+        run: ../detect_variants/index.cwl
+        in:
+            vcf: fp_bgzip/bgzipped_file
+        out:
+            [indexed_vcf]
+    hard_filter:
+        run: select_variants.cwl
+        in:
+            reference: reference
+            vcf: fp_index/indexed_vcf
+            exclude_filtered: hard_filter_vcf
+            output_vcf_basename: filtered_vcf_basename
+        out:
+            [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -15,8 +15,8 @@ inputs:
     vcf:
         type: File
         secondaryFiles: [.tbi]
-    output_vcf_basename:
-        type: string
+    variant_caller:
+        string?
 outputs:
     unfiltered_vcf:
         type: File
@@ -40,8 +40,9 @@ steps:
             reference: reference
             bam: cram_to_bam/bam
             vcf: vcf
+            variant_caller: variant_caller
             output_vcf_basename: 
-                valueFrom: $(inputs.output_vcf_basename + "_unfiltered")
+                valueFrom: $(inputs.variant_caller)_unfiltered
         out:
             [filtered_vcf]
     fp_bgzip:
@@ -63,8 +64,9 @@ steps:
             vcf: fp_index/indexed_vcf
             exclude_filtered: 
                 default: true
+            variant_caller: variant_caller
             output_vcf_basename: 
-                valueFrom: $(inputs.output_vcf_basename + "_filtered")
+                valueFrom: $(inputs.variant_caller)_filtered
         out:
             [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -3,8 +3,6 @@
 cwlVersion: v1.0
 class: Workflow
 label: "fp_filter workflow"
-requirements:
-    - class: InlineJavascriptRequirement
 inputs:
     cram:
         type: File
@@ -16,7 +14,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     variant_caller:
-        string?
+        string
 outputs:
     unfiltered_vcf:
         type: File
@@ -40,9 +38,9 @@ steps:
             reference: reference
             bam: cram_to_bam/bam
             vcf: vcf
-            variant_caller: variant_caller
-            output_vcf_basename: 
-                valueFrom: $(inputs.variant_caller)_unfiltered
+            output_vcf_basename:
+                source: variant_caller
+                valueFrom: $(self)_unfiltered
         out:
             [filtered_vcf]
     fp_bgzip:
@@ -64,9 +62,9 @@ steps:
             vcf: fp_index/indexed_vcf
             exclude_filtered: 
                 default: true
-            variant_caller: variant_caller
-            output_vcf_basename: 
-                valueFrom: $(inputs.variant_caller)_filtered
+            output_vcf_basename:
+                source: variant_caller
+                valueFrom: $(self)_filtered
         out:
             [filtered_vcf]
 

--- a/fp_filter/workflow.cwl
+++ b/fp_filter/workflow.cwl
@@ -58,7 +58,7 @@ steps:
         out:
             [indexed_vcf]
     hard_filter:
-        run: select_variants.cwl
+        run: ../detect_variants/select_variants.cwl
         in:
             reference: reference
             vcf: fp_index/indexed_vcf

--- a/mutect/mutect.cwl
+++ b/mutect/mutect.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 20000
       tmpdirMin: 100000
 arguments:
-    ["-o", { valueFrom: $(runtime.outdir)/output.vcf.gz }]
+    ["-o", { valueFrom: $(runtime.outdir)/mutect.vcf.gz }]
 inputs:
     reference:
         type: File
@@ -55,5 +55,5 @@ outputs:
     vcf:
         type: File
         outputBinding:
-            glob: "output.vcf.gz"
+            glob: "mutect.vcf.gz"
         secondaryFiles: [.tbi]

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -72,6 +72,6 @@ steps:
             vcf: merge/merged_vcf
             output_vcf_basename: mutect
         out:
-            [filtered_vcf]
+            [unfiltered_vcf, filtered_vcf]
 
 

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type: File
@@ -71,7 +72,7 @@ steps:
             cram: tumor_cram
             vcf: merge/merged_vcf
             output_vcf_basename: 
-                default: "mutect"
+                valueFrom: "mutect"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -70,7 +70,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: mutect
+            output_vcf_basename: "mutect"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -30,9 +30,13 @@ inputs:
     artifact_detection_mode:
         type: boolean
 outputs:
-    merged_vcf:
+    unfiltered_vcf:
         type: File
-        outputSource: fp_index/indexed_vcf
+        outputSource: filter/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    filtered_vcf:
+        type: File
+        outputSource: filter/filtered_vcf
         secondaryFiles: [.tbi]
 steps:
     split_interval_list:
@@ -66,18 +70,8 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
+            output_vcf_basename: mutect
         out:
             [filtered_vcf]
-    fp_bgzip:
-        run: ../detect_variants/bgzip.cwl
-        in:
-            file: filter/filtered_vcf
-        out:
-            [bgzipped_file]
-    fp_index:
-        run: ../detect_variants/index.cwl
-        in:
-            vcf: fp_bgzip/bgzipped_file
-        out:
-            [indexed_vcf]
+
 

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -7,7 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
-    - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type: File

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -70,7 +70,8 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: "mutect"
+            output_vcf_basename: 
+                default: "mutect"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/mutect/workflow.cwl
+++ b/mutect/workflow.cwl
@@ -71,7 +71,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: 
+            variant_caller: 
                 valueFrom: "mutect"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -94,6 +94,6 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: pindel
+            output_vcf_basename: "pindel"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -23,9 +23,13 @@ inputs:
         type: int
         default: 400
 outputs:
-    merged_vcf:
+    unfiltered_vcf:
         type: File
-        outputSource: fp_index/indexed_vcf
+        outputSource: filter/unfiltered_vcf
+        secondaryFiles: [".tbi"]
+    filtered_vcf:
+        type: File
+        outputSource: filter/filtered_vcf
         secondaryFiles: [".tbi"]
 steps:
     get_chromosome_list:
@@ -90,17 +94,6 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
+            output_vcf_basename: pindel
         out:
             [filtered_vcf]
-    fp_bgzip:
-        run: ../detect_variants/bgzip.cwl
-        in:
-            file: filter/filtered_vcf
-        out:
-            [bgzipped_file]
-    fp_index:
-        run: ../detect_variants/index.cwl
-        in:
-            vcf: fp_bgzip/bgzipped_file
-        out:
-            [indexed_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -94,6 +94,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: "pindel"
+            output_vcf_basename: 
+                default: "pindel"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type: File
@@ -95,6 +96,6 @@ steps:
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
             output_vcf_basename: 
-                default: "pindel"
+                valueFrom: "pindel"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -7,7 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
-    - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type: File

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -96,4 +96,4 @@ steps:
             vcf: region_filter/filtered_vcf
             output_vcf_basename: pindel
         out:
-            [filtered_vcf]
+            [unfiltered_vcf, filtered_vcf]

--- a/pindel/workflow.cwl
+++ b/pindel/workflow.cwl
@@ -95,7 +95,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: 
+            variant_caller: 
                 valueFrom: "pindel"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -22,9 +22,13 @@ inputs:
     exome_mode:
         type: boolean
 outputs:
-    merged_vcf:
+    unfiltered_vcf:
         type: File
-        outputSource: fp_index/indexed_vcf
+        outputSource: filter/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    filtered_vcf:
+        type: File
+        outputSource: filter/filtered_vcf
         secondaryFiles: [.tbi]
 steps:
     strelka:
@@ -69,20 +73,9 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
+            output_vcf_basename: strelka
         out:
             [filtered_vcf]
-    fp_bgzip:
-        run: ../detect_variants/bgzip.cwl
-        in:
-            file: filter/filtered_vcf
-        out:
-            [bgzipped_file]
-    fp_index:
-        run: ../detect_variants/index.cwl
-        in:
-            vcf: fp_bgzip/bgzipped_file
-        out:
-            [indexed_vcf]
 
 
 

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -75,7 +75,7 @@ steps:
             vcf: region_filter/filtered_vcf
             output_vcf_basename: strelka
         out:
-            [filtered_vcf]
+            [unfiltered_vcf, filtered_vcf]
 
 
 

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     tumor_cram:
         type: File
@@ -74,7 +75,7 @@ steps:
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
             output_vcf_basename: 
-                default: "strelka"
+                valueFrom: "strelka"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -73,7 +73,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: strelka
+            output_vcf_basename: "strelka"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -73,7 +73,8 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: "strelka"
+            output_vcf_basename: 
+                default: "strelka"
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -7,7 +7,7 @@ requirements:
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
-    - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     tumor_cram:
         type: File

--- a/strelka/workflow.cwl
+++ b/strelka/workflow.cwl
@@ -74,7 +74,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: region_filter/filtered_vcf
-            output_vcf_basename: 
+            variant_caller: 
                 valueFrom: "strelka"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -107,6 +107,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: "varscan"
+            output_vcf_basename: 
+                default: "varscan"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -109,4 +109,4 @@ steps:
             vcf: merge/merged_vcf
             output_vcf_basename: varscan
         out:
-            [filtered_vcf]
+            [unfiltered_vcf, filtered_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -108,7 +108,7 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: 
+            variant_caller: 
                 valueFrom: "varscan"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -6,7 +6,7 @@ label: "Varscan Workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
-    - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type: File

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -6,6 +6,7 @@ label: "Varscan Workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type: File
@@ -108,6 +109,6 @@ steps:
             cram: tumor_cram
             vcf: merge/merged_vcf
             output_vcf_basename: 
-                default: "varscan"
+                valueFrom: "varscan"
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -19,17 +19,13 @@ inputs:
     interval_list:
         type: File
 outputs:
-    snvs:
+    unfiltered_vcf:
         type: File
-        outputSource: index_snvs/indexed_vcf
+        outputSource: filter/unfiltered_vcf
         secondaryFiles: [.tbi]
-    indels:
+    filtered_vcf:
         type: File
-        outputSource: index_indels/indexed_vcf
-        secondaryFiles: [.tbi]
-    merged_vcf:
-        type: File
-        outputSource: fp_index/indexed_vcf
+        outputSource: filter/filtered_vcf
         secondaryFiles: [.tbi]
 steps:
     intervals_to_bed:
@@ -111,17 +107,6 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
+            output_vcf_basename: varscan
         out:
             [filtered_vcf]
-    fp_bgzip:
-        run: ../detect_variants/bgzip.cwl
-        in:
-            file: filter/filtered_vcf
-        out:
-            [bgzipped_file]
-    fp_index:
-        run: ../detect_variants/index.cwl
-        in:
-            vcf: fp_bgzip/bgzipped_file
-        out:
-            [indexed_vcf]

--- a/varscan/workflow.cwl
+++ b/varscan/workflow.cwl
@@ -107,6 +107,6 @@ steps:
             reference: reference
             cram: tumor_cram
             vcf: merge/merged_vcf
-            output_vcf_basename: varscan
+            output_vcf_basename: "varscan"
         out:
             [unfiltered_vcf, filtered_vcf]


### PR DESCRIPTION
I moved the hard filter, bgzip and index into the fp_filter/workflow.cwl.

In addition, I attempted to add an optional `output_vcf_basename` parameter that can be used to keep the names of the per-caller VCFs from conflicting. However, that doesn't work as I expected.

Any feedback on this would be great. I'm open to other ideas or ways of accomplishing:
#131 #133 #134 